### PR TITLE
Temporary buffers cannot be deleted.

### DIFF
--- a/elscreen-separate-buffer-list.el
+++ b/elscreen-separate-buffer-list.el
@@ -158,25 +158,46 @@
         do (esbl-separate-buffer-list-count-inc i)))
 
 (defun esbl-kill:around (origin &rest args)
-  "SCREENの削除時にBUFFERの削除、SEPARATE-BUFFER-LISTの復元をする."
-  (mapc (lambda (buffer)
-          (unless (member (buffer-name buffer) esbl-separate-buffer-list-default)
-            (kill-buffer buffer)))
-        (buffer-list))
-  (apply origin args)
-  (esbl-restore-separate-buffer-list (elscreen-get-current-screen)))
+  "SCREENの削除時にBUFFERのカウントを下げ、SEPARATE-BUFFER-LISTの復元をする."
+  (let* ((screen (or (and (integerp (car args)) (car args))
+                     (elscreen-get-current-screen)))
+         (separate-buffer-list
+          (when (elscreen-screen-live-p screen)
+            (if (eq screen (elscreen-get-current-screen))
+                (esbl-get-separate-buffer-list)
+              (assoc-default 'separate-buffer-list
+                             (elscreen-get-screen-property screen)))))
+         (one-screen-p (and (eq screen (elscreen-get-current-screen))
+                            (elscreen-one-screen-p)))
+         (origin-return (apply origin args)))
+    (when (or origin-return one-screen-p)
+      (mapc (lambda (buffer)
+              (unless (member (buffer-name buffer) esbl-separate-buffer-list-default)
+                (esbl-separate-buffer-list-count-dec buffer)))
+            separate-buffer-list)
+      (when one-screen-p
+        (esbl-set-default-separate-buffer-list)
+        (esbl-save-separate-buffer-list (elscreen-get-current-screen))
+        (elscreen-apply-window-configuration (elscreen-default-window-configuration)))
+      (esbl-restore-separate-buffer-list (elscreen-get-current-screen)))
+    origin-return))
 
 (defun esbl-kill-buffer-hook ()
   "BUFFER削除時にSEPARATE-BUFFER-LISTからも削除する."
   (let ((buffer (current-buffer)))
     (when (member buffer (esbl-get-separate-buffer-list))
-      (esbl-remove-separate-buffer-list buffer)
-      (if elscreen-separate-buffer-list-mode
-          (if (> 1 (esbl-separate-buffer-list-count buffer))
-              t
-            (bury-buffer)
-            nil)
-        t))))
+      (esbl-remove-separate-buffer-list buffer))
+    (if elscreen-separate-buffer-list-mode
+        (if (> 1 (esbl-separate-buffer-list-count buffer))
+            t
+          (walk-windows
+           `(lambda (win)
+              (when (eq (window-buffer win) ,buffer)
+                (switch-to-prev-buffer win t)))
+           nil (window-frame))
+          (bury-buffer buffer)
+          nil)
+      t)))
 
 (defun esbl-buffer-list-update-hook ()
   "BUFFER-LIST更新時にSEPARATE-BUFFER-LISTも更新する."

--- a/elscreen-separate-buffer-list.el
+++ b/elscreen-separate-buffer-list.el
@@ -158,7 +158,7 @@
         do (esbl-separate-buffer-list-count-inc i)))
 
 (defun esbl-kill:around (origin &rest args)
-  "SCREENの削除時にBUFFERのカウントを下げ、SEPARATE-BUFFER-LISTの復元をする."
+  "SCREENの削除時にBUFFERの削除、SEPARATE-BUFFER-LISTの復元をする."
   (let* ((screen (or (and (integerp (car args)) (car args))
                      (elscreen-get-current-screen)))
          (separate-buffer-list
@@ -173,7 +173,9 @@
     (when (or origin-return one-screen-p)
       (mapc (lambda (buffer)
               (unless (member (buffer-name buffer) esbl-separate-buffer-list-default)
-                (esbl-separate-buffer-list-count-dec buffer)))
+                (unless (eq screen (elscreen-get-current-screen))
+                  (esbl-separate-buffer-list-count-dec buffer))
+                (kill-buffer buffer)))
             separate-buffer-list)
       (when one-screen-p
         (esbl-set-default-separate-buffer-list)


### PR DESCRIPTION
with-temp-buffer などが一時的なバッファを作って削除されるはずのバッファが buffer-list から削除されていないという現象が起きました．

上記の問題に対する部分修正をしてみたのですが，いかがでしょうか．

ご確認よろしくお願いします．

以下のコードで *temp* バッファが削除されないことを確認できます．

``` lisp
(let* ((count-temp-buffer
        (lambda ()
           (cl-loop for buf in (buffer-list)
                    when (string-match-p "*temp*" (buffer-name buf))
                    count buf)))
       (before (funcall count-temp-buffer))
       (after-with-temp-buffer
        (progn
          (cl-loop repeat 10 do (with-temp-buffer))
          (funcall count-temp-buffer)))
       (after-kill-buffer
        (progn
          (cl-loop for buf in (buffer-list)
                   when (string-match-p "*temp*" (buffer-name buf))
                   do (kill-buffer buf))
          (funcall count-temp-buffer)))
       (diff1 (- after-with-temp-buffer before))
       (diff2 (- after-kill-buffer before)))
  (message "after with-temp-buffer : %s, after kill-buffer : %s"
           diff1 diff2))
```
